### PR TITLE
Fix naming of node unique identifier

### DIFF
--- a/GPM.DynamicRecon/DynamicReconParamsNode.cs
+++ b/GPM.DynamicRecon/DynamicReconParamsNode.cs
@@ -20,7 +20,7 @@ internal class DynamicReconParamsNode : AnalysisNodeBase
 
 	public static NodeDisplayInfo DisplayInfo { get; } = new();
 
-	public const string UniqueId = "GPM.CustomAnalysis.IsopositionFiltering.IsopositionFilteringNode";
+	public const string UniqueId = "GPM.CustomAnalysis.DynamicRecon.DynamicReconParamsNode";
 
 	private readonly DynamicReconParams dynamicReconParam;
 


### PR DESCRIPTION
Code had been copied from a different extension and not properly
updated. This meant that the unique id clashed if both extensions
were installed at the same time and this extension was effectively
overridden by the other.